### PR TITLE
ci: add typescript tsc check

### DIFF
--- a/.github/workflows/tsc-check.yaml
+++ b/.github/workflows/tsc-check.yaml
@@ -1,0 +1,31 @@
+name: Run Typescript check
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+  merge_group:
+
+# this prevents multiple jobs from the same pr
+# running when new changes are pushed.
+concurrency:
+  group: ${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: Tsc Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js 22
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+    - name: Install bun
+      run: npm install -g bun
+    - name: Install dependencies
+      run: bun install
+    - name: Run tsc check
+      run: bun check

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier ./src --write",
     "format:check": "prettier ./src --check",
     "test": "bun test",
+    "check": "tsc --noEmit",
     "generate": "bun --silent api:filter && bun --silent api:generate",
     "api:filter": "bun --silent ./tools/openapi/filter.ts",
     "api:generate": "bun --silent ./tools/openapi/generate.ts"


### PR DESCRIPTION
This slipped through the cracks which means commits with typescript errors might have made it through.