### PR TITLE
Replace fs actions with a dedicated store

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ curl --unix-socket /run/decomposer-httpd.sock \
 
 - `GET /api/image-builder-composer/v2/composes` - Get collection of compose requests
 - `POST /api/image-builder-composer/v2/compose` - Create a new compose request
+- `GET /api/image-builder-composer/v2/composes/:id` - Get status of a specific compose request
 - `DELETE /api/image-builder-composer/v2/compose/:id` - Delete a specific compose
 
 #### Examples
@@ -114,6 +115,10 @@ curl --unix-socket /run/decomposer-httpd.sock \
   }'
 ```
 
+```bash
+curl --unix-socket /run/decomposer-httpd.sock \
+  -X GET 'http://localhost/api/image-builder-composer/v2/composes/YOUR-COMPOSE-ID'
+```
 
 ```bash
 curl --unix-socket /run/decomposer-httpd.sock \

--- a/generated/ibcrc/v1/api.json
+++ b/generated/ibcrc/v1/api.json
@@ -176,6 +176,24 @@
           "description": "Id of compose"
         }
       ],
+      "get": {
+        "summary": "get status of an image compose",
+        "description": "status of an image compose",
+        "operationId": "getComposeStatus",
+        "tags": ["compose"],
+        "responses": {
+          "200": {
+            "description": "compose status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComposeStatus"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "summary": "delete a compose",
         "description": "Deletes a compose, the compose will still count towards quota.\n",
@@ -289,6 +307,138 @@
             "type": "string"
           },
           "last": {
+            "type": "string"
+          }
+        }
+      },
+      "ComposeStatus": {
+        "required": ["image_status", "request"],
+        "properties": {
+          "image_status": {
+            "$ref": "#/components/schemas/ImageStatus"
+          },
+          "request": {
+            "$ref": "#/components/schemas/ComposeRequest"
+          }
+        }
+      },
+      "ImageStatus": {
+        "required": ["status"],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "success",
+              "failure",
+              "pending",
+              "building",
+              "uploading",
+              "registering"
+            ],
+            "example": "success"
+          },
+          "upload_status": {
+            "$ref": "#/components/schemas/UploadStatus"
+          },
+          "error": {
+            "$ref": "#/components/schemas/ComposeStatusError"
+          }
+        }
+      },
+      "ComposeStatusError": {
+        "required": ["id", "reason"],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "UploadStatus": {
+        "required": ["status", "type", "options"],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["success", "failure", "pending", "running"]
+          },
+          "type": {
+            "$ref": "#/components/schemas/UploadTypes"
+          },
+          "options": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AWSUploadStatus"
+              },
+              {
+                "$ref": "#/components/schemas/AWSS3UploadStatus"
+              },
+              {
+                "$ref": "#/components/schemas/GCPUploadStatus"
+              },
+              {
+                "$ref": "#/components/schemas/AzureUploadStatus"
+              },
+              {
+                "$ref": "#/components/schemas/OCIUploadStatus"
+              }
+            ]
+          }
+        }
+      },
+      "AWSUploadStatus": {
+        "type": "object",
+        "required": ["ami", "region"],
+        "properties": {
+          "ami": {
+            "type": "string",
+            "example": "ami-0c830793775595d4b"
+          },
+          "region": {
+            "type": "string",
+            "example": "eu-west-1"
+          }
+        }
+      },
+      "AWSS3UploadStatus": {
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "GCPUploadStatus": {
+        "type": "object",
+        "required": ["project_id", "image_name"],
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "example": "ascendant-braid-303513"
+          },
+          "image_name": {
+            "type": "string",
+            "example": "my-image"
+          }
+        }
+      },
+      "AzureUploadStatus": {
+        "type": "object",
+        "required": ["image_name"],
+        "properties": {
+          "image_name": {
+            "type": "string",
+            "example": "my-image"
+          }
+        }
+      },
+      "OCIUploadStatus": {
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+          "url": {
             "type": "string"
           }
         }

--- a/generated/ibcrc/v1/zod.ts
+++ b/generated/ibcrc/v1/zod.ts
@@ -462,6 +462,59 @@ export const ComposesResponse = z
   })
   .passthrough();
 
+export const AWSUploadStatus = z
+  .object({ ami: z.string(), region: z.string() })
+  .passthrough();
+
+export const AWSS3UploadStatus = z.object({ url: z.string() }).passthrough();
+
+export const GCPUploadStatus = z
+  .object({ project_id: z.string(), image_name: z.string() })
+  .passthrough();
+
+export const AzureUploadStatus = z
+  .object({ image_name: z.string() })
+  .passthrough();
+
+export const OCIUploadStatus = z.object({ url: z.string() }).passthrough();
+
+export const UploadStatus = z
+  .object({
+    status: z.enum(['success', 'failure', 'pending', 'running']),
+    type: UploadTypes,
+    options: z.union([
+      AWSUploadStatus,
+      AWSS3UploadStatus,
+      GCPUploadStatus,
+      AzureUploadStatus,
+      OCIUploadStatus,
+    ]),
+  })
+  .passthrough();
+
+export const ComposeStatusError = z
+  .object({ id: z.number().int(), reason: z.string() })
+  .passthrough();
+
+export const ImageStatus = z
+  .object({
+    status: z.enum([
+      'success',
+      'failure',
+      'pending',
+      'building',
+      'uploading',
+      'registering',
+    ]),
+    upload_status: UploadStatus.optional(),
+    error: ComposeStatusError.optional(),
+  })
+  .passthrough();
+
+export const ComposeStatus = z
+  .object({ image_status: ImageStatus, request: ComposeRequest })
+  .passthrough();
+
 export const ComposeResponse = z
   .object({ id: z.string().uuid() })
   .passthrough();

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "hono-pino": "0.9.1",
     "http-status-codes": "2.3.0",
     "pino": "9.7.0",
+    "pouchdb": "9.0.0",
     "uuid": "11.1.0",
     "zod": "4.0.2"
   },
@@ -35,6 +36,7 @@
     "@trivago/prettier-plugin-sort-imports": "5.2.2",
     "@types/bun": "1.2.18",
     "@types/node": "24.0.10",
+    "@types/pouchdb": "6.4.2",
     "@typescript-eslint/eslint-plugin": "8.35.1",
     "@typescript-eslint/parser": "8.35.1",
     "eslint": "9.30.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "openapi-format": "1.27.1",
     "openapi-types": "12.1.3",
     "openapi-zod-client": "1.18.3",
+    "pouchdb-adapter-memory": "9.0.0",
     "prettier": "3.6.2",
     "ts-node": "10.9.2",
     "typescript": "5.8.3",

--- a/src/__fixtures__/index.ts
+++ b/src/__fixtures__/index.ts
@@ -6,3 +6,5 @@ export { composeRequest } from './compose-request';
 export const blueprint = await Bun.file(
   path.join(__dirname, 'blueprint.json'),
 ).json();
+
+export { createTestStore } from './store';

--- a/src/__fixtures__/store.ts
+++ b/src/__fixtures__/store.ts
@@ -1,0 +1,15 @@
+import pouchdb from 'pouchdb';
+import memoryAdapter from 'pouchdb-adapter-memory';
+
+import { ComposeDoc } from '@app/types';
+
+pouchdb.plugin(memoryAdapter);
+
+export const createTestStore = () => {
+  const composesStore: PouchDB.Database<ComposeDoc> = new pouchdb('composes', {
+    adapter: 'memory',
+  });
+  return {
+    composes: composesStore,
+  };
+};

--- a/src/__mocks__/worker.ts
+++ b/src/__mocks__/worker.ts
@@ -1,7 +1,9 @@
+import { Status } from '@app/types';
+
 export const runJob = async (request: { id: string; request: string }) => {
   const proc = Bun.spawn({
     cmd: ['echo', request.request],
   });
   await proc.exited;
-  return { id: request.id, result: 'success' };
+  return { id: request.id, result: Status.SUCCESS };
 };

--- a/src/__mocks__/worker.ts
+++ b/src/__mocks__/worker.ts
@@ -3,5 +3,5 @@ export const runJob = async (request: { id: string; request: string }) => {
     cmd: ['echo', request.request],
   });
   await proc.exited;
-  return 'success';
+  return { id: request.id, result: 'success' };
 };

--- a/src/api/composes/composes.test.ts
+++ b/src/api/composes/composes.test.ts
@@ -28,7 +28,9 @@ describe('Composes handler tests', async () => {
         // inject a mock executable here so that we don't actually run ibcli
         const queue = new JobQueue<ComposeRequest>(buildImage(tmp, executable));
         ctx.set('queue', queue);
-        ctx.set('store', tmp);
+        // @ts-expect-error we haven't implemented a test db yet
+        // so this is expected to fail
+        ctx.set('store', { path: tmp });
         await next();
       })
       .route('/', composes),

--- a/src/api/composes/composes.test.ts
+++ b/src/api/composes/composes.test.ts
@@ -56,7 +56,7 @@ describe('Composes handler tests', async () => {
     const res = await client.compose.$post({
       json: composeRequest,
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(StatusCodes.OK);
     const { id } = await res.json();
     newCompose = id;
     expect(validate(id)).toBeTrue();
@@ -66,7 +66,7 @@ describe('Composes handler tests', async () => {
     // delay the request so we can finish simulating
     // the post request
     const res = await client.composes.$get();
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(StatusCodes.OK);
     const body = (await res.json()) as ComposesResponse;
     expect(body).not.toBeUndefined();
     expect(body.meta.count).toBe(1);
@@ -75,10 +75,11 @@ describe('Composes handler tests', async () => {
   });
 
   it('DELETE /compose/:id should delete a compose', async () => {
+    await Bun.sleep(4);
     const res = await client.compose[':id'].$delete({
       param: { id: newCompose },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(StatusCodes.OK);
   });
 
   it('GET /composes should empty again', async () => {
@@ -107,6 +108,9 @@ describe('Composes handler tests', async () => {
   });
 
   it('DELETE /compose/:id with corrupt directory should return 500', async () => {
+    // just wait for the scheduled job to run, otherwise this causes
+    // the tests to break
+    await Bun.sleep(1);
     await rmdir(path.join(tmp, newCompose), { recursive: true });
     Bun.sleep(2);
     const res = await client.compose[':id'].$delete({

--- a/src/api/composes/index.ts
+++ b/src/api/composes/index.ts
@@ -13,7 +13,7 @@ export const composes = new Hono<ComposeContext>()
   .use(async (ctx, next) => {
     const queue = ctx.get('queue');
     const store = ctx.get('store');
-    ctx.set('service', new ComposeService(queue, store.path));
+    ctx.set('service', new ComposeService(queue, store));
     await next();
   })
 

--- a/src/api/composes/index.ts
+++ b/src/api/composes/index.ts
@@ -1,7 +1,12 @@
 import { Hono } from 'hono';
 
 import { ComposeService } from './service';
-import { ComposeContext, ComposeResponse, ComposesResponse } from './types';
+import {
+  ComposeContext,
+  ComposeResponse,
+  ComposeStatusResponse,
+  ComposesResponse,
+} from './types';
 import * as validators from './validators';
 
 export const composes = new Hono<ComposeContext>()
@@ -44,6 +49,20 @@ export const composes = new Hono<ComposeContext>()
     const service = ctx.get('service');
     const { id } = await service.add(ctx.req.valid('json'));
     return ctx.json<ComposeResponse>({ id });
+  })
+
+  // curl --unix-socket /run/decomposer-httpd.sock \
+  // -X GET 'http://localhost/api/image-builder-composer/v2/compose/123e4567-e89b-12d3-a456-426655440000'
+  .get('/composes/:id', async (ctx) => {
+    const id = ctx.req.param('id');
+    const service = ctx.get('service');
+    const compose = await service.get(id);
+    return ctx.json<ComposeStatusResponse>({
+      request: compose.request!,
+      image_status: {
+        status: compose.status,
+      },
+    });
   })
 
   // curl --unix-socket /run/decomposer-httpd.sock \

--- a/src/api/composes/index.ts
+++ b/src/api/composes/index.ts
@@ -5,7 +5,6 @@ import { ComposeContext, ComposeResponse, ComposesResponse } from './types';
 import * as validators from './validators';
 
 export const composes = new Hono<ComposeContext>()
-
   // Rather than initialising the service inside each
   // handler, we can just inject it through middleware.
   // Each handler will then have access to service via app context
@@ -14,7 +13,7 @@ export const composes = new Hono<ComposeContext>()
   .use(async (ctx, next) => {
     const queue = ctx.get('queue');
     const store = ctx.get('store');
-    ctx.set('service', new ComposeService(queue, store));
+    ctx.set('service', new ComposeService(queue, store.path));
     await next();
   })
 

--- a/src/api/composes/types.ts
+++ b/src/api/composes/types.ts
@@ -1,12 +1,14 @@
 import z from 'zod';
 
-import { AppContext, ComposeRequest } from '@app/types';
+import { AppContext, ComposeDoc, ComposeRequest } from '@app/types';
 import * as schema from '@gen/ibcrc/zod';
 
 export type Compose = z.infer<typeof schema.ComposesResponseItem>;
 export type ComposesResponse = z.infer<typeof schema.ComposesResponse>;
 
 export type ComposeResponse = z.infer<typeof schema.ComposeResponse>;
+
+export type ComposeStatusResponse = z.infer<typeof schema.ComposeStatus>;
 
 export type ComposeContext = AppContext & {
   Variables: {
@@ -17,5 +19,6 @@ export type ComposeContext = AppContext & {
 export type ComposeService = {
   composes: () => Promise<Compose[]>;
   add: (request: ComposeRequest) => Promise<{ id: string }>;
+  get: (id: string) => Promise<ComposeDoc>;
   delete: (id: string) => Promise<void>;
 };

--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -1,2 +1,3 @@
 export { JobQueue } from './queue';
 export { buildImage } from './worker';
+export * from './types';

--- a/src/queue/queue.test.ts
+++ b/src/queue/queue.test.ts
@@ -23,10 +23,7 @@ describe('Test the worker queue', () => {
     queue.enqueue({ id: 'task1', request: 'First task' });
     expect(queueProcessorSpy).toHaveBeenCalledTimes(1);
     expect(queue.current).toStrictEqual({ id: 'task1', request: 'First task' });
-    // simulate job execution
-    setTimeout(() => {
-      expect(queueProcessorSpy).toHaveBeenCalledTimes(2);
-    }, 200);
+    expect(queueProcessorSpy).toHaveBeenCalledTimes(1);
   });
 
   it('enqueuing 3 requests should call the process function multiple times', () => {
@@ -38,13 +35,10 @@ describe('Test the worker queue', () => {
     expect(queueProcessorSpy).toHaveBeenCalledTimes(3);
     expect(queue.queue.length).toBe(2);
     expect(queue.current).toStrictEqual({ id: 'task1', request: 'First task' });
-    // simulate job execution
-    setTimeout(() => {
-      expect(queueProcessorSpy).toHaveBeenCalledTimes(4);
-    }, 200);
+    expect(queueProcessorSpy).toHaveBeenCalledTimes(3);
   });
 
-  it('completed queue should have no items and current should not be set', () => {
+  it('completed queue should have no items and current should not be set', async () => {
     expect(queue.queue.length).toBe(0);
     queue.enqueue({ id: 'task1', request: 'First task' });
     expect(queueProcessorSpy).toHaveBeenCalledTimes(1);
@@ -52,12 +46,8 @@ describe('Test the worker queue', () => {
     expect(queueProcessorSpy).toHaveBeenCalledTimes(2);
     expect(queue.current).toStrictEqual({ id: 'task1', request: 'First task' });
     expect(queue.queue.length).toBe(1);
-    // simulate job execution
-    setTimeout(() => {
-      expect(queueProcessorSpy).toHaveBeenCalledTimes(4);
-      expect(queue.current).toBe({ id: 'task2', request: 'Second task' });
-      expect(queue.queue.length).toBe(0);
-      expect(queue.current).not.toBeDefined();
-    }, 200);
+    // wait for all the jobs to clear the queue
+    await Bun.sleep(4);
+    expect(queue.current).not.toBeDefined();
   });
 });

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -51,8 +51,9 @@ export class JobQueue<T> {
     }
 
     return this.run(job).catch((err) => {
-      // There was most likely an error saving the request or blueprint
-      // to the artifacts directory, we should just move on to the next job
+      // Just handle the error and return a failed result, there
+      // was some issue either saving the blueprint to the state
+      // directory or with the build itself
       logger.error('There was an error executing the job', err);
       return 'failure';
     });

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -33,6 +33,22 @@ export class JobQueue<T> {
     return this.current;
   }
 
+  public remove(id: string) {
+    this.queue = this.queue.filter((job) => job.id === id);
+  }
+
+  public contains(id: string) {
+    return this.queue.some((job) => job.id === id);
+  }
+
+  public isCurrent(id: string) {
+    if (!this.current) {
+      return false;
+    }
+
+    return id === this.current.id;
+  }
+
   public async process() {
     if (this.queue.length === 0) {
       return;

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:stream';
 
 import { logger } from '@app/logger';
+import { JobResult } from '@app/types';
 
 import { Job, Worker } from './types';
 
@@ -14,8 +15,9 @@ export class JobQueue<T> {
     this.queue = [];
     this.run = cmd;
     this.events = new EventEmitter();
-    this.events.on('completed', () => {
+    this.events.on('completed', (result: JobResult) => {
       logger.info('Queue ready');
+      this.events.emit('update', result);
       this.current = undefined;
       this.process();
     });
@@ -50,12 +52,17 @@ export class JobQueue<T> {
       return;
     }
 
-    return this.run(job).catch((err) => {
-      // Just handle the error and return a failed result, there
-      // was some issue either saving the blueprint to the state
-      // directory or with the build itself
-      logger.error('There was an error executing the job', err);
-      return 'failure';
-    });
+    this.events.emit('update', { id: job.id, result: 'building' });
+    return await this.run(job)
+      .then((result) => {
+        return result;
+      })
+      .catch((err) => {
+        // Just handle the error and return a failed result, there
+        // was some issue either saving the blueprint to the state
+        // directory or with the build itself
+        logger.error('There was an error executing the job', err);
+        return { id: job.id, result: 'failure' };
+      });
   }
 }

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -1,6 +1,8 @@
+import { JobResult } from '@app/types';
+
 export type Job<T> = {
   id: string;
   request: T;
 };
 
-export type Worker<T> = (request: Job<T>) => Promise<string>;
+export type Worker<T> = (request: Job<T>) => Promise<JobResult>;

--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -4,7 +4,7 @@ import z from 'zod';
 
 import { mapHostedToOnPrem } from '@app/blueprint';
 import { logger } from '@app/logger';
-import { ComposeRequest } from '@app/types';
+import { ComposeRequest, JobResult, Status } from '@app/types';
 import { jsonFormat } from '@app/utilities';
 import { Customizations } from '@gen/ibcrc/zod';
 
@@ -31,7 +31,7 @@ export const buildImage = (
   store: string,
   executable: string = 'image-builder',
 ) => {
-  return async ({ request, id }: Job<ComposeRequest>) => {
+  return async ({ request, id }: Job<ComposeRequest>): Promise<JobResult> => {
     const outputDir = path.join(store, id);
     await mkdir(outputDir, { recursive: true });
     const bpPath = await saveBlueprint(outputDir, id, request.customizations);
@@ -61,11 +61,11 @@ export const buildImage = (
     if (proc.exitCode === 0) {
       logger.info(`✅ Image build successful: ${id}`);
       await Bun.file(path.join(outputDir, 'result')).write('success');
-      return { id, result: 'success' };
+      return { id, result: Status.SUCCESS };
     }
 
     logger.info(`❌ Image build failed: ${id}`);
     await Bun.file(path.join(outputDir, 'result')).write('failure');
-    return { id, result: 'failure' };
+    return { id, result: Status.FAILURE };
   };
 };

--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -12,12 +12,6 @@ import { Job } from './types';
 
 type Customizations = z.infer<typeof Customizations>;
 
-const saveRequest = async (outputDir: string, request: ComposeRequest) => {
-  await Bun.file(path.join(outputDir, 'request.json')).write(
-    jsonFormat(request),
-  );
-};
-
 const saveBlueprint = async (
   outputDir: string,
   id: string,
@@ -40,7 +34,6 @@ export const buildImage = (
   return async ({ request, id }: Job<ComposeRequest>) => {
     const outputDir = path.join(store, id);
     await mkdir(outputDir, { recursive: true });
-    await saveRequest(outputDir, request);
     const bpPath = await saveBlueprint(outputDir, id, request.customizations);
 
     // there should only be one item, we have already validated this

--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -61,11 +61,11 @@ export const buildImage = (
     if (proc.exitCode === 0) {
       logger.info(`✅ Image build successful: ${id}`);
       await Bun.file(path.join(outputDir, 'result')).write('success');
-      return 'success';
+      return { id, result: 'success' };
     }
 
     logger.info(`❌ Image build failed: ${id}`);
     await Bun.file(path.join(outputDir, 'result')).write('failure');
-    return 'failure';
+    return { id, result: 'failure' };
   };
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,12 @@
+import path from 'path';
+import pouchdb from 'pouchdb';
+
+import { ComposeDoc } from '@app/types';
+
+export const createStore = (store: string) => {
+  const composesPath = path.join(store, 'composes');
+  const composesStore: PouchDB.Database<ComposeDoc> = new pouchdb(composesPath);
+  return {
+    composes: composesStore,
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,17 +6,29 @@ import { ComposeRequest as CRCComposeRequest } from '@gen/ibcrc/zod';
 
 export type ComposeRequest = z.infer<typeof CRCComposeRequest>;
 
+export enum Status {
+  SUCCESS = 'success',
+  FAILURE = 'failure',
+  PENDING = 'pending',
+  BUILDING = 'building',
+}
+
 export type ComposeDoc = {
   _id: string;
   _rev?: string;
   created_at: string;
-  status: string;
+  status: Status;
   request?: ComposeRequest;
 };
 
 export type JobResult = {
   id: string;
-  result: string;
+  result: Status;
+};
+
+export type JobMessage = {
+  type: string;
+  data: JobResult;
 };
 
 export type Store = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,11 @@ export type ComposeDoc = {
   request?: ComposeRequest;
 };
 
+export type JobResult = {
+  id: string;
+  result: string;
+};
+
 export type Store = {
   path: string;
   composes: PouchDB.Database<ComposeDoc>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,22 @@ import { ComposeRequest as CRCComposeRequest } from '@gen/ibcrc/zod';
 
 export type ComposeRequest = z.infer<typeof CRCComposeRequest>;
 
+export type ComposeDoc = {
+  _id: string;
+  _rev?: string;
+  created_at: string;
+  status: string;
+  request?: ComposeRequest;
+};
+
+export type Store = {
+  path: string;
+  composes: PouchDB.Database<ComposeDoc>;
+};
+
 export type AppContext = {
   Variables: {
-    store: string;
+    store: Store;
     logger: typeof logger;
     queue: Queue<ComposeRequest>;
   };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,4 +1,5 @@
 import { SOCKET_PATH } from '@app/constants';
+import { AppError, DatabaseError, isPouchError } from '@app/errors';
 
 export const removeSocket = async () => {
   if (await Bun.file(SOCKET_PATH).exists()) {
@@ -16,4 +17,20 @@ export const prettyPrint = (o: object) => {
 
 export const jsonFormat = (o: object) => {
   return JSON.stringify(o, null, 2);
+};
+
+export const withTransaction = async <T>(
+  operation: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await operation();
+  } catch (error) {
+    if (isPouchError(error)) {
+      throw new DatabaseError(error);
+    }
+    throw new AppError({
+      message: 'Unable to complete transaction',
+      details: [error],
+    });
+  }
 };

--- a/tools/openapi/configs/ibcrc.ts
+++ b/tools/openapi/configs/ibcrc.ts
@@ -20,6 +20,7 @@ const filterOptions = {
       'getComposes',
       'composeImage',
       'deleteCompose',
+      'getComposeStatus',
       'createBlueprint',
     ],
     unusedComponents: [


### PR DESCRIPTION
- adds a pouchdb store for managing composes
- adds a new `Database` error type for handling errors with the store
- fixes some more issues with the test suites
- fixes a logic bug when trying to delete a compose that is currently being built
- adds a GET /composes/:id endpoint for getting the build status of a compose