### PR TITLE
ci: update the timeout for the integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier ./src --write",
     "format:check": "prettier ./src --check",
     "test:unit": "bun test ./src",
-    "test:integration": "bun test ./integration",
+    "test:integration": "bun test --timeout 10000 ./integration",
     "check": "tsc --noEmit",
     "generate": "bun --silent api:filter && bun --silent api:generate",
     "api:filter": "bun --silent ./tools/openapi/filter.ts",


### PR DESCRIPTION
The default timeout was 5 seconds. The manifest generation part of the tests would timeout since they took longer than 5 seconds causing some flakiness in the tests. This commit extends the timeout duration to 10 seconds.