### PR TITLE
api/composes: add model abstraction layer for db

### DIFF
--- a/src/__fixtures__/store.ts
+++ b/src/__fixtures__/store.ts
@@ -1,14 +1,18 @@
 import pouchdb from 'pouchdb';
 import memoryAdapter from 'pouchdb-adapter-memory';
 
-import { ComposeDoc } from '@app/store';
+import { ComposeDocument } from '@app/store';
 
 pouchdb.plugin(memoryAdapter);
 
 export const createTestStore = (store: string) => {
-  const composesStore: PouchDB.Database<ComposeDoc> = new pouchdb('composes', {
-    adapter: 'memory',
-  });
+  const composesStore: PouchDB.Database<ComposeDocument> = new pouchdb(
+    'composes',
+    {
+      adapter: 'memory',
+    },
+  );
+
   return {
     path: store,
     composes: composesStore,

--- a/src/api/composes/index.ts
+++ b/src/api/composes/index.ts
@@ -57,16 +57,11 @@ export const composes = new Hono<AppContext>()
   .get('/composes/:id', async (ctx) => {
     const id = ctx.req.param('id');
     const { compose: service } = ctx.get('services');
-    const result = await service.get(id);
+    const result = await service.status(id);
 
     return result.match({
-      Ok: (compose) => {
-        return ctx.json<ComposeStatus>({
-          request: compose.request!,
-          image_status: {
-            status: compose.status,
-          },
-        });
+      Ok: (status) => {
+        return ctx.json<ComposeStatus>(status);
       },
       Err: (error) => {
         const { body, code } = error.response();

--- a/src/api/composes/model.ts
+++ b/src/api/composes/model.ts
@@ -1,0 +1,97 @@
+import { Mutex } from 'async-mutex';
+import { StatusCodes } from 'http-status-codes';
+import { mkdir, rmdir } from 'node:fs/promises';
+import path from 'node:path';
+import * as Task from 'true-myth/task';
+import { v4 as uuid } from 'uuid';
+
+import { Status } from '@app/constants';
+import { AppError, withAppError } from '@app/errors';
+import { ComposeDocument } from '@app/store';
+import { ComposesResponseItem } from '@gen/ibcrc/zod';
+
+import { Compose, ComposeRequest } from './types';
+
+export class Model {
+  private db: PouchDB.Database<ComposeDocument>;
+  private store: string;
+  private mutex: Mutex;
+
+  constructor(store: string, db: PouchDB.Database<ComposeDocument>) {
+    this.db = db;
+    this.store = store;
+    this.mutex = new Mutex();
+  }
+
+  async create(request: ComposeRequest) {
+    return Task.tryOrElse(withAppError, async () => {
+      const id = uuid();
+      await mkdir(path.join(this.store, id), { recursive: true });
+      return this.db.put({
+        _id: id,
+        created_at: new Date().toISOString(),
+        status: Status.PENDING,
+        request,
+      });
+    });
+  }
+
+  async findAll() {
+    return Task.tryOrElse(withAppError, async (): Promise<Compose[]> => {
+      const docs = await this.db.allDocs({
+        include_docs: true,
+      });
+
+      return docs.rows
+        .map((row) => row.doc!)
+        .map((compose: ComposeDocument) => {
+          const parsed = ComposesResponseItem.safeParse({
+            id: compose._id,
+            ...compose,
+          });
+
+          if (!parsed.success) {
+            throw new AppError({
+              code: StatusCodes.INTERNAL_SERVER_ERROR,
+              message:
+                'Unable to retrieve compose: stored compose data is invalid',
+              details: parsed.error.issues,
+            });
+          }
+
+          return parsed.data;
+        });
+    });
+  }
+
+  async findById(id: string) {
+    return Task.tryOrElse(withAppError, () => this.db.get(id));
+  }
+
+  async update(id: string, changes: Partial<ComposeDocument>) {
+    return Task.tryOrElse(withAppError, async () => {
+      const compose = await this.findById(id);
+      if (compose.isErr) {
+        throw compose.error;
+      }
+
+      await this.mutex.runExclusive(async () => {
+        await this.db.put({
+          ...compose.value,
+          ...changes,
+        });
+      });
+    });
+  }
+
+  async delete(id: string) {
+    return Task.tryOrElse(withAppError, async () => {
+      const compose = await this.db.get(id);
+
+      await this.mutex.runExclusive(async () => {
+        await this.db.remove(compose);
+        await rmdir(path.join(this.store, id), { recursive: true });
+      });
+    });
+  }
+}

--- a/src/api/composes/types.ts
+++ b/src/api/composes/types.ts
@@ -1,21 +1,22 @@
-import { Result } from 'true-myth/result';
+import { Status } from '@app/constants';
+import { ComposeDocument } from '@app/store';
+import { type Schemas } from '@gen/ibcrc';
 
-import { DatabaseError } from '@app/errors';
-import { ComposeDoc } from '@app/store';
-import { Schemas } from '@gen/ibcrc';
+import { ServiceTask as Task } from '../types';
 
+export type ComposeBuildStatus = { status: Status };
 export type Compose = Schemas['ComposesResponseItem'];
 export type ComposeRequest = Schemas['ComposeRequest'];
 export type Composes = Schemas['ComposesResponse'];
 export type ComposeId = Schemas['ComposeResponse'];
 export type ComposeStatus = Schemas['ComposeStatus'];
 
-type ServiceTask<T> = Promise<Result<T, DatabaseError>>;
+export type ComposeWithBuildStatus = Omit<Compose, 'id'> & ComposeBuildStatus;
 
 export type ComposeService = {
-  composes: () => ServiceTask<Compose[]>;
-  add: (request: ComposeRequest) => ServiceTask<ComposeId>;
-  get: (id: string) => ServiceTask<ComposeDoc>;
-  update: (id: string, changes: ComposeDoc) => ServiceTask<void>;
-  delete: (id: string) => ServiceTask<unknown>;
+  composes: () => Task<Compose[]>;
+  add: (request: ComposeRequest) => Task<ComposeId>;
+  status: (id: string) => Task<ComposeStatus>;
+  update: (id: string, changes: Partial<ComposeDocument>) => Task<void>;
+  delete: (id: string) => Task<unknown>;
 };

--- a/src/api/pagination.ts
+++ b/src/api/pagination.ts
@@ -1,0 +1,23 @@
+import { Maybe } from 'true-myth/maybe';
+
+export const asPaginatedResponse = <T extends { id: string }>(
+  items: T[],
+  limit: Maybe<string>,
+  offset: Maybe<string>,
+) => {
+  const length = items.length;
+  const first = length > 0 ? items[0].id : '';
+  const last = length > 0 ? items[length - 1].id : '';
+
+  const l = limit.map((v) => parseInt(v)).unwrapOr(100);
+  const o = offset.map((v) => parseInt(v)).unwrapOr(0);
+
+  return {
+    meta: { count: length },
+    links: {
+      first,
+      last,
+    },
+    data: items.slice(o, o + l),
+  };
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,5 @@
+import { Result } from 'true-myth/result';
+
+import { DatabaseError } from '@app/errors';
+
+export type ServiceTask<T> = Promise<Result<T, DatabaseError>>;

--- a/src/errors/database.ts
+++ b/src/errors/database.ts
@@ -10,25 +10,6 @@ export const isPouchError = (err: unknown): err is PouchDB.Core.Error => {
   );
 };
 
-export const withDatabaseError = (error: unknown) => {
-  if (error instanceof Error && isPouchError(error)) {
-    return new DatabaseError(error);
-  }
-
-  if (error instanceof DatabaseError || error instanceof AppError) {
-    return error;
-  }
-
-  if (error instanceof Error && error.name === 'OpenError') {
-    return new DatabaseError(error);
-  }
-
-  return new AppError({
-    message: 'Unable to complete transaction',
-    details: [error],
-  });
-};
-
 export class DatabaseError extends AppError {
   constructor(error: unknown) {
     if (error instanceof Error && error.name === 'OpenError') {

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,4 @@
 export { AppError } from './app';
-export { DatabaseError, withDatabaseError } from './database';
+export { DatabaseError } from './database';
 export { ValidationError } from './validation';
-export { onError, notFound } from './handlers';
+export { onError, notFound, withAppError } from './handlers';

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,25 +1,28 @@
 import path from 'path';
 import pouchdb from 'pouchdb';
 
-import { ComposeRequest } from '@app/api/composes';
-import { Status } from '@app/constants';
+import { ComposeWithBuildStatus } from '@app/api/composes';
 
-export type ComposeDoc = {
+type Document = {
   _id: string;
   _rev?: string;
-  created_at: string;
-  status: Status;
-  request?: ComposeRequest;
 };
+
+// pouchdb uses `_id` instead of `id` for the primary key
+// we also want to keep track of the compose status in the document,
+// so we add that type too
+export type ComposeDocument = Document & ComposeWithBuildStatus;
 
 export type Store = {
   path: string;
-  composes: PouchDB.Database<ComposeDoc>;
+  composes: PouchDB.Database<ComposeDocument>;
 };
 
 export const createStore = (store: string) => {
   const composesPath = path.join(store, 'composes');
-  const composesStore: PouchDB.Database<ComposeDoc> = new pouchdb(composesPath);
+  const composesStore: PouchDB.Database<ComposeDocument> = new pouchdb(
+    composesPath,
+  );
   return {
     path: store,
     composes: composesStore,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { ComposeService, DistributionService } from '@app/api';
 import type { Logger } from '@app/logger';
 
-export type { ComposeDoc, Store } from '@app/store';
+export type { ComposeDocument, Store } from '@app/store';
 export type { Job, JobResult, Worker } from '@app/worker';
 
 export type AppContext = {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -20,10 +20,6 @@ export const jsonFormat = (o: object) => {
   return JSON.stringify(o, null, 2);
 };
 
-// this is a simple higher order function so that we can
-// execute a promise with `true-myth` tasks
-export const resolve = <T>(fn: () => Promise<T>): Promise<T> => fn();
-
 export const imageTypeLookup = {
   hostedToOnPrem: (distro: string, imageType: string) => {
     // TODO: add these aliases to the images library:

--- a/src/worker/save-blueprint.ts
+++ b/src/worker/save-blueprint.ts
@@ -1,6 +1,4 @@
-import { mkdir } from 'fs/promises';
 import path from 'path';
-import { Result } from 'true-myth/result';
 import * as Task from 'true-myth/task';
 import z from 'zod';
 
@@ -10,20 +8,11 @@ import { Customizations } from '@gen/ibcrc/zod';
 
 type Customizations = z.infer<typeof Customizations>;
 
-const createArtifactsDir = async (outputDir: string) => {
-  return Task.fromPromise(mkdir(outputDir, { recursive: true }));
-};
-
 export const saveBlueprint = async (
   outputDir: string,
   id: string,
   customizations?: Customizations,
 ) => {
-  const dirResult = await createArtifactsDir(outputDir);
-  if (dirResult.isErr) {
-    return Result.err(dirResult.error);
-  }
-
   const blueprint = mapHostedToOnPrem({
     name: id,
     customizations: customizations || {},


### PR DESCRIPTION
This is another layer of abstraction, but the composes service was getting quite complicated
in the cases where it needed to fetch the data from the store and then transform it. We can 
just add a model layer and delegate some of these tasks there.