### PR TITLE
ci: fix manifest generation workflow

### DIFF
--- a/.github/workflows/code-generation.yaml
+++ b/.github/workflows/code-generation.yaml
@@ -44,12 +44,17 @@ jobs:
   generate-test-manifests:
     name: Generate test manifests
     runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:latest
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js 22
       uses: actions/setup-node@v4
       with:
         node-version: 22
+    - name: Install image-builder
+      run: dnf install -y image-builder
+    - name: Check image-builder
+      run: image-builder --version
     - name: Install bun
       run: npm install -g bun
     - name: Install dependencies


### PR DESCRIPTION
We need image-builder-cli to do this, so we need to run the action inside a fedora container and install the cli.