### PR TITLE
multi: stricter typescript types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,12 +34,19 @@ export default defineConfig([
       globals: {
         ...globals.node,
       },
-
-      parser: tsParser,
     },
   },
   {
     files: ['**/*.ts'],
+
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: __dirname,
+      },
+    },
+
     rules: {
       'no-restricted-exports': [
         'error',
@@ -47,6 +54,17 @@ export default defineConfig([
           restrictDefaultExports: { direct: true },
         },
       ],
+
+      // this works nicely with the typescript `verbatimModuleSyntax` rule
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          fixStyle: 'separate-type-imports',
+        },
+      ],
+      '@typescript-eslint/consistent-type-exports': 'error',
+      '@typescript-eslint/no-import-type-side-effects': 'error',
     },
   },
 ]);

--- a/src/__fixtures__/compose-request.ts
+++ b/src/__fixtures__/compose-request.ts
@@ -1,6 +1,6 @@
-import z from 'zod';
+import type z from 'zod';
 
-import { ComposeRequest } from '@gen/ibcrc/zod';
+import type { ComposeRequest } from '@gen/ibcrc/zod';
 
 export const composeRequest: z.infer<typeof ComposeRequest> = {
   distribution: 'centos-9',

--- a/src/__fixtures__/customizations.ts
+++ b/src/__fixtures__/customizations.ts
@@ -1,6 +1,6 @@
-import z from 'zod';
+import type z from 'zod';
 
-import { Customizations } from '@gen/ibcrc/zod';
+import type { Customizations } from '@gen/ibcrc/zod';
 
 export const customizations: z.infer<typeof Customizations> = {
   hostname: 'my-host',

--- a/src/__fixtures__/store.ts
+++ b/src/__fixtures__/store.ts
@@ -1,7 +1,7 @@
 import pouchdb from 'pouchdb';
 import memoryAdapter from 'pouchdb-adapter-memory';
 
-import { BlueprintDocument, ComposeDocument } from '@app/store';
+import type { BlueprintDocument, ComposeDocument } from '@app/store';
 
 pouchdb.plugin(memoryAdapter);
 

--- a/src/__mocks__/ibcli-list.ts
+++ b/src/__mocks__/ibcli-list.ts
@@ -1,5 +1,5 @@
-import { Distribution, ImageType } from '@app/api/distributions/types';
-import { Architecture } from '@app/constants';
+import type { Distribution, ImageType } from '@app/api/distributions/types';
+import type { Architecture } from '@app/constants';
 
 import { imageTypes } from '@fixtures';
 
@@ -9,7 +9,7 @@ export const ibcliList = async (
 ): Promise<ImageType[]> => {
   return new Promise((resolve) =>
     resolve(
-      imageTypes[distribution]
+      (imageTypes[distribution] ?? [])
         .filter((type) => type.arch === arch)
         .flatMap((type) => type.image_types)
         .map((type) => ({

--- a/src/api/blueprints/blueprints.test.ts
+++ b/src/api/blueprints/blueprints.test.ts
@@ -8,8 +8,8 @@ import { validate } from 'uuid';
 import { blueprintRequest } from '@fixtures';
 import { createTestClient } from '@mocks';
 
-import { BlueprintRequest, Blueprints } from '.';
-import { Composes } from '../composes';
+import type { BlueprintRequest, Blueprints } from '.';
+import type { Composes } from '../composes';
 
 describe('Blueprints handler tests', async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), 'decomposer-test'));

--- a/src/api/blueprints/index.ts
+++ b/src/api/blueprints/index.ts
@@ -1,11 +1,16 @@
 import { Hono } from 'hono';
 import Maybe from 'true-myth/maybe';
 
-import { AppContext } from '@app/types';
+import type { AppContext } from '@app/types';
 
-import { Compose, ComposeId, Composes } from '../composes';
+import type { Compose, ComposeId, Composes } from '../composes';
 import { asPaginatedResponse } from '../pagination';
-import { Blueprint, BlueprintId, BlueprintMetadata, Blueprints } from './types';
+import type {
+  Blueprint,
+  BlueprintId,
+  BlueprintMetadata,
+  Blueprints,
+} from './types';
 import * as validators from './validators';
 
 export const blueprints = new Hono<AppContext>()
@@ -155,4 +160,4 @@ export const blueprints = new Hono<AppContext>()
     });
   });
 
-export * from './types';
+export type * from './types';

--- a/src/api/blueprints/model.ts
+++ b/src/api/blueprints/model.ts
@@ -2,10 +2,14 @@ import * as Task from 'true-myth/task';
 import { v4 as uuid } from 'uuid';
 
 import { withAppError } from '@app/errors';
-import { BlueprintDocument } from '@app/store';
+import type { BlueprintDocument } from '@app/store';
 import { maybeEmptyObject } from '@app/utilities';
 
-import { BlueprintBody, BlueprintMetadata, BlueprintRequest } from './types';
+import type {
+  BlueprintBody,
+  BlueprintMetadata,
+  BlueprintRequest,
+} from './types';
 import * as validators from './validators';
 
 export class Model {

--- a/src/api/blueprints/service.ts
+++ b/src/api/blueprints/service.ts
@@ -1,10 +1,10 @@
 import { Result } from 'true-myth/result';
 
-import { Store } from '@app/store';
+import type { Store } from '@app/store';
 
-import { ComposeRequest, ComposeService } from '../composes';
+import type { ComposeRequest, ComposeService } from '../composes';
 import { Model } from './model';
-import {
+import type {
   BlueprintBody,
   BlueprintRequest,
   BlueprintService as Service,
@@ -36,7 +36,7 @@ export class BlueprintService implements Service {
       id: blueprint._id,
       name: blueprint.name,
       version: blueprint.version,
-      description: blueprint.description,
+      description: blueprint.description ?? '',
       last_modified_at: blueprint.last_modified_at,
     }));
   }

--- a/src/api/blueprints/types.ts
+++ b/src/api/blueprints/types.ts
@@ -1,7 +1,7 @@
-import { Schemas } from '@gen/ibcrc';
+import type { Schemas } from '@gen/ibcrc';
 
-import { ComposeId } from '../composes';
-import { ServiceTask as Task } from '../types';
+import type { ComposeId } from '../composes';
+import type { ServiceTask as Task } from '../types';
 
 export type BlueprintMetadata = Schemas['BlueprintItem'];
 export type Blueprints = Schemas['BlueprintsResponse'];

--- a/src/api/blueprints/validators.ts
+++ b/src/api/blueprints/validators.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { parserFor } from 'true-myth-zod';
 
 import { DatabaseError, ValidationError } from '@app/errors';
-import { BlueprintDocument } from '@app/store';
+import type { BlueprintDocument } from '@app/store';
 import {
   BlueprintItem,
   CreateBlueprintRequest,

--- a/src/api/composes/composes.test.ts
+++ b/src/api/composes/composes.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from 'bun:test';
-import { ContentfulStatusCode } from 'hono/utils/http-status';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { StatusCodes } from 'http-status-codes';
 import { mkdtemp, rmdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -9,7 +9,7 @@ import { validate } from 'uuid';
 import { composeRequest } from '@fixtures';
 import { createTestClient } from '@mocks';
 
-import { Composes } from './types';
+import type { Composes } from './types';
 
 describe('Composes handler tests', async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), 'decomposer-test'));

--- a/src/api/composes/index.ts
+++ b/src/api/composes/index.ts
@@ -1,10 +1,10 @@
 import { Hono } from 'hono';
 import Maybe from 'true-myth/maybe';
 
-import { AppContext } from '@app/types';
+import type { AppContext } from '@app/types';
 
 import { asPaginatedResponse } from '../pagination';
-import { Compose, ComposeId, ComposeStatus, Composes } from './types';
+import type { Compose, ComposeId, ComposeStatus, Composes } from './types';
 import * as validators from './validators';
 
 export const composes = new Hono<AppContext>()
@@ -86,4 +86,4 @@ export const composes = new Hono<AppContext>()
     });
   });
 
-export * from './types';
+export type * from './types';

--- a/src/api/composes/model.ts
+++ b/src/api/composes/model.ts
@@ -1,15 +1,15 @@
 import { Mutex } from 'async-mutex';
 import { mkdir, rmdir } from 'node:fs/promises';
 import path from 'node:path';
-import { Maybe } from 'true-myth/maybe';
+import type { Maybe } from 'true-myth/maybe';
 import * as Task from 'true-myth/task';
 import { v4 as uuid } from 'uuid';
 
 import { Status } from '@app/constants';
 import { withAppError } from '@app/errors';
-import { ComposeDocument } from '@app/store';
+import type { ComposeDocument } from '@app/store';
 
-import { Compose, ComposeRequest } from './types';
+import type { Compose, ComposeRequest } from './types';
 import * as validators from './validators';
 
 export class Model {

--- a/src/api/composes/service.ts
+++ b/src/api/composes/service.ts
@@ -2,11 +2,11 @@ import { StatusCodes } from 'http-status-codes';
 import { Maybe, Result } from 'true-myth';
 
 import { AppError } from '@app/errors';
-import { JobQueue } from '@app/queue';
-import { ComposeDocument, JobResult, Store } from '@app/types';
+import type { JobQueue } from '@app/queue';
+import type { ComposeDocument, JobResult, Store } from '@app/types';
 
 import { Model } from './model';
-import { ComposeRequest, ComposeService as Service } from './types';
+import type { ComposeRequest, ComposeService as Service } from './types';
 
 export class ComposeService implements Service {
   private model: Model;

--- a/src/api/composes/types.ts
+++ b/src/api/composes/types.ts
@@ -1,8 +1,8 @@
-import { Status } from '@app/constants';
-import { ComposeDocument } from '@app/store';
-import { type Schemas } from '@gen/ibcrc';
+import type { Status } from '@app/constants';
+import type { ComposeDocument } from '@app/store';
+import type { Schemas } from '@gen/ibcrc';
 
-import { ServiceTask as Task } from '../types';
+import type { ServiceTask as Task } from '../types';
 
 export type ComposeBuildStatus = { status: Status };
 export type Compose = Schemas['ComposesResponseItem'];

--- a/src/api/composes/validators.ts
+++ b/src/api/composes/validators.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { parserFor } from 'true-myth-zod';
 
 import { DatabaseError, ValidationError } from '@app/errors';
-import { ComposeDocument } from '@app/types';
+import type { ComposeDocument } from '@app/types';
 import { ComposeRequest, ComposesResponseItem } from '@gen/ibcrc/zod';
 
 // The zod schema ensures that there is only one single

--- a/src/api/distributions/distributions.test.ts
+++ b/src/api/distributions/distributions.test.ts
@@ -4,7 +4,7 @@ import { testClient } from 'hono/testing';
 import { StatusCodes } from 'http-status-codes';
 import z from 'zod';
 
-import { AppContext } from '@app/types';
+import type { AppContext } from '@app/types';
 import { ImageTypes } from '@gen/ibcrc/zod';
 
 import { ibcliList } from '@mocks';
@@ -12,7 +12,7 @@ import { ibcliList } from '@mocks';
 import { distributions } from '.';
 import { list } from './distribution-list';
 import { DistributionService } from './service';
-import { Architectures, Distributions } from './types';
+import type { Architectures, Distributions } from './types';
 
 // this is just a zod helper so we can parse the whole list
 // of image types in one go and ensure that they are okay

--- a/src/api/distributions/index.ts
+++ b/src/api/distributions/index.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono';
 
-import { AppContext } from '@app/types';
+import type { AppContext } from '@app/types';
 
-import { Architectures, Distribution, Distributions } from './types';
+import type { Architectures, Distribution, Distributions } from './types';
 
 export const distributions = new Hono<AppContext>()
 

--- a/src/api/distributions/service.ts
+++ b/src/api/distributions/service.ts
@@ -10,8 +10,13 @@ import { ImageTypes } from '@gen/ibcrc/zod';
 // pre-load the json list of distribution data on app
 // startup and inject it to the route through middleware
 import { list } from './distribution-list';
-import { DistributionService as Service } from './types';
-import { Architectures, Distribution, Distributions, ImageType } from './types';
+import type { DistributionService as Service } from './types';
+import type {
+  Architectures,
+  Distribution,
+  Distributions,
+  ImageType,
+} from './types';
 
 const ibcliList = async (
   distribution: Distribution,

--- a/src/api/distributions/types.ts
+++ b/src/api/distributions/types.ts
@@ -1,7 +1,7 @@
-import { Result } from 'true-myth/result';
+import type { Result } from 'true-myth/result';
 
-import { AppError } from '@app/errors';
-import { Schemas } from '@gen/ibcrc';
+import type { AppError } from '@app/errors';
+import type { Schemas } from '@gen/ibcrc';
 
 export type Architectures = Schemas['Architectures'];
 export type Distributions = Schemas['DistributionsResponse'];

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,6 +13,6 @@ export const services = {
   Distribution: DistributionService,
 };
 
-export * from './blueprints/types';
-export * from './composes/types';
-export * from './distributions/types';
+export type * from './blueprints/types';
+export type * from './composes/types';
+export type * from './distributions/types';

--- a/src/api/meta.ts
+++ b/src/api/meta.ts
@@ -1,4 +1,4 @@
-import { Context } from 'hono';
+import type { Context } from 'hono';
 import { Hono } from 'hono';
 
 // load the openapi spec on app startup

--- a/src/api/pagination.ts
+++ b/src/api/pagination.ts
@@ -6,8 +6,12 @@ export const asPaginatedResponse = <T extends { id: string }>(
   offset: Maybe<string>,
 ) => {
   const length = items.length;
-  const first = length > 0 ? items[0].id : '';
-  const last = length > 0 ? items[length - 1].id : '';
+  const first = Maybe.of<T>(items[0])
+    .map((item: T) => item.id)
+    .unwrapOr('');
+  const last = Maybe.of<T>(items[length - 1])
+    .map((item: T) => item.id)
+    .unwrapOr('');
 
   const l = limit.map((v) => parseInt(v)).unwrapOr(100);
   const o = offset.map((v) => parseInt(v)).unwrapOr(0);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,6 +1,6 @@
-import { Result } from 'true-myth/result';
+import type { Result } from 'true-myth/result';
 
-import { AppError, DatabaseError, ValidationError } from '@app/errors';
+import type { AppError, DatabaseError, ValidationError } from '@app/errors';
 
 export type ServiceTask<T> = Promise<
   Result<T, DatabaseError | ValidationError | AppError>

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,14 +3,15 @@ import { pinoLogger } from 'hono-pino';
 import { prettyJSON } from 'hono/pretty-json';
 
 import * as api from '@app/api';
-import { ComposeRequest, services } from '@app/api';
+import type { ComposeRequest } from '@app/api';
+import { services } from '@app/api';
 import { API_ENDPOINT } from '@app/constants';
 import { notFound, onError } from '@app/errors';
 import { logger } from '@app/logger';
 import { createQueue } from '@app/queue';
-import { Store } from '@app/store';
-import { AppContext } from '@app/types';
-import { Worker } from '@app/worker';
+import type { Store } from '@app/store';
+import type { AppContext } from '@app/types';
+import type { Worker } from '@app/worker';
 
 export const createApp = (
   socket: string,

--- a/src/blueprint/hosted-to-on-prem.ts
+++ b/src/blueprint/hosted-to-on-prem.ts
@@ -1,7 +1,7 @@
-import z from 'zod';
+import type z from 'zod';
 
 import * as cloudapi from '@gen/cloudapi/zod';
-import * as ibcrc from '@gen/ibcrc/zod';
+import type * as ibcrc from '@gen/ibcrc/zod';
 
 type CreateBlueprintRequest = Pick<
   z.infer<typeof ibcrc.CreateBlueprintRequest>,

--- a/src/errors/app.ts
+++ b/src/errors/app.ts
@@ -1,4 +1,4 @@
-import { ContentfulStatusCode } from 'hono/utils/http-status';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { StatusCodes } from 'http-status-codes';
 
 type AppErrorProps = {

--- a/src/errors/database.ts
+++ b/src/errors/database.ts
@@ -1,4 +1,4 @@
-import { ContentfulStatusCode } from 'hono/utils/http-status';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 import { AppError } from './app';
 

--- a/src/errors/handlers.ts
+++ b/src/errors/handlers.ts
@@ -1,4 +1,4 @@
-import { ErrorHandler, NotFoundHandler } from 'hono';
+import type { ErrorHandler, NotFoundHandler } from 'hono';
 import { StatusCodes } from 'http-status-codes';
 
 import { AppError } from './app';

--- a/src/errors/validation.ts
+++ b/src/errors/validation.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
-import { $ZodError } from 'zod/v4/core';
+import type { $ZodError } from 'zod/v4/core';
 
 import { AppError } from './app';
 

--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -1,5 +1,5 @@
-import { ComposeRequest } from '@app/api/composes';
-import { Worker } from '@app/worker';
+import type { ComposeRequest } from '@app/api/composes';
+import type { Worker } from '@app/worker';
 
 import { JobQueue } from './queue';
 

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:stream';
 
 import { Status } from '@app/constants';
 import { logger } from '@app/logger';
-import { Job, JobResult, Worker } from '@app/worker';
+import type { Job, JobResult, Worker } from '@app/worker';
 
 export class JobQueue<T> {
   current?: Job<T> | undefined;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 import pouchdb from 'pouchdb';
 
-import { BlueprintWithRequest } from '@app/api/blueprints';
-import { ComposeWithBuildStatus } from '@app/api/composes';
+import type { BlueprintWithRequest } from '@app/api/blueprints';
+import type { ComposeWithBuildStatus } from '@app/api/composes';
 
 type Document = {
   _id: string;

--- a/src/worker/build-image.ts
+++ b/src/worker/build-image.ts
@@ -1,12 +1,14 @@
 import path from 'path';
+import { Maybe } from 'true-myth/maybe';
 import { Result } from 'true-myth/result';
 import * as Task from 'true-myth/task';
 
-import { ComposeRequest } from '@app/api/composes';
+import type { ComposeRequest } from '@app/api/composes';
+import { AppError } from '@app/errors';
 import { imageTypeLookup } from '@app/utilities';
 
 import { saveBlueprint } from './save-blueprint';
-import { Job, WorkerArgs } from './types';
+import type { Job, WorkerArgs } from './types';
 
 export const buildImage = ({
   store,
@@ -21,10 +23,16 @@ export const buildImage = ({
 
     const bpPath = bpResult.value;
 
+    const imageRequest = Maybe.of(request.image_requests[0]);
+    if (imageRequest.isNothing) {
+      // this really shouldn't happen since we validate the image request at
+      // the api handler level, but it is an additional runtime check, so it's ok
+      return Result.err(new AppError({ message: 'Image request is empty' }));
+    }
+
     const imageType = imageTypeLookup.hostedToOnPrem(
       request.distribution,
-      // there should only be one item, we have already validated this
-      request.image_requests[0].image_type,
+      imageRequest.value.image_type,
     );
 
     const proc = Bun.spawn(

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,4 +1,4 @@
-import { Store } from '@app/store';
+import type { Store } from '@app/store';
 
 import { buildImage } from './build-image';
 import { buildManifest } from './build-manifest';
@@ -17,4 +17,4 @@ export const createWorker = (
 
 export { buildImage, buildManifest };
 
-export * from './types';
+export type * from './types';

--- a/src/worker/save-blueprint.ts
+++ b/src/worker/save-blueprint.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 import * as Task from 'true-myth/task';
-import z from 'zod';
+import type z from 'zod';
 
 import { mapHostedToOnPrem } from '@app/blueprint';
 import { jsonFormat } from '@app/utilities';
-import { Customizations } from '@gen/ibcrc/zod';
+import type { Customizations } from '@gen/ibcrc/zod';
 
 type Customizations = z.infer<typeof Customizations>;
 

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -1,6 +1,6 @@
-import { Result } from 'true-myth/result';
+import type { Result } from 'true-myth/result';
 
-import { Status } from '@app/constants';
+import type { Status } from '@app/constants';
 
 export type WorkerArgs = {
   store: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,22 @@
 {
   "compilerOptions": {
-    "noImplicitAny": true,
     "target": "es2021",
     "module": "esnext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
     "strict": true,
     "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "paths": {
       "@app/*": ["./src/*"],


### PR DESCRIPTION
Adjust the typescript config to have stricter types and adjust the linter to account for this.

The primary reason for the change was so that the frontend and the shim have matching types. Since `exactOptionalPropertyTypes` is set in the frontend.

Additionally, if we are importing a type, we should be explicit and include the `type` keyword in the import statement.